### PR TITLE
修复找不到bilibili.js的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@
 	};
 
 	bili.addScripts = function (scripts, callback) {
-		scripts.push('/assets/src/bilibili.js');
+		scripts.push('/plugins/nodebb-plugin-bilibili-bv/lib/bilibili.js');
 		callback(null, scripts);
 	}
 })(module.exports);


### PR DESCRIPTION
解决开发者调试中提示找不到bilibili.js的问题。
虽然我这样改了之后不报错了，功能也正常，不过我非常不熟悉NodeJS，不确定这样调整是不是正确的选择